### PR TITLE
Remove .dev.vars file and add to gitignore

### DIFF
--- a/.dev.vars
+++ b/.dev.vars
@@ -1,1 +1,0 @@
-NEXTJS_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+.dev.vars
 
 # cloudflare
 .open-next


### PR DESCRIPTION
## Summary
This PR removes the committed `.dev.vars` file and adds it to `.gitignore` to prevent environment-specific development variables from being tracked in version control.

## Key Changes
- Deleted `.dev.vars` file that contained `NEXTJS_ENV=development`
- Added `.dev.vars` to `.gitignore` to ensure environment files are not committed in the future

## Details
The `.dev.vars` file appears to be a local development environment configuration file that should not be part of the repository. By removing it and adding the pattern to `.gitignore`, we ensure that each developer can maintain their own local environment variables without them being tracked or conflicting with other contributors' configurations.

https://claude.ai/code/session_01ReUfjEm5aSi7cghSJhLKUq