### PR TITLE
Update .gitignore to ignore all .dev.vars files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,5 @@
   },
   "enabledMcpjsonServers": [
     "next-devtools"
-  ],
-  "verbose": true
+  ]
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "enabledPlugins": {
+ "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "feature-dev@claude-plugins-official": true,
     "commit-commands@claude-plugins-official": true,
@@ -9,7 +9,5 @@
     "claude-md-management@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true
   },
-  "enabledMcpjsonServers": [
-    "next-devtools"
-  ]
+  "enabledMcpjsonServers": ["next-devtools"]
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
- "enabledPlugins": {
+  "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "feature-dev@claude-plugins-official": true,
     "commit-commands@claude-plugins-official": true,
@@ -9,5 +9,8 @@
     "claude-md-management@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true
   },
-  "enabledMcpjsonServers": ["next-devtools"]
+  "enabledMcpjsonServers": [
+    "next-devtools"
+  ],
+  "verbose": true
 }

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
-.dev.vars
+.dev.vars*
 
 # cloudflare
 .open-next


### PR DESCRIPTION
## Summary
Updated the `.gitignore` file to use a wildcard pattern for environment variable files, ensuring all `.dev.vars` files and their variants are properly ignored by git.

## Changes
- Modified `.dev.vars` pattern to `.dev.vars*` in `.gitignore` to match any `.dev.vars` file with additional suffixes or extensions

## Details
This change allows git to ignore not just `.dev.vars` but also any files matching the pattern (e.g., `.dev.vars.local`, `.dev.vars.example`, etc.), providing more flexible handling of development environment variable files across different environments and configurations.

https://claude.ai/code/session_01Sxe4PFEx75AU6VaVRq4CsB